### PR TITLE
Export Lightcurves to SkyPortal

### DIFF
--- a/src/dataset.py
+++ b/src/dataset.py
@@ -2244,14 +2244,14 @@ class Lightcurve(DatasetMixin, Base):
         return ax
 
     def get_sncosmo_filter(self, filter):
-        if self.observatory == "ztf":
+        if self.observatory.lower() == "ztf":
             d = dict(zg="ztfg", zr="ztfi", zi="ztfz")
-        elif self.observatory == "tess":
+        elif self.observatory.lower() == "tess":
             d = dict(tess="tess::red")
         else:
             d = {}
 
-        return d.get(filter, filter)
+        return d.get(filter.lower(), filter)
 
     def export_to_skyportal(self, filename="lightcurve.h5", overwrite=False):
         """
@@ -2287,10 +2287,18 @@ class Lightcurve(DatasetMixin, Base):
             dec=self.altdata["dec"],
             series_name=self.altdata["series_name"],
             series_obj_id=self.altdata["object_id"],
-            ra_unc=self.altdata.get("ra_err", None),
-            dec_unc=self.altdata.get("dec_err", None),
-            time_stamp_alignment=self.altdata.get("time_stamp_alignment", None),
         )
+
+        if "ra_err" in self.altdata:
+            metadata["ra_unc"] = self.altdata["ra_err"]
+        if "dec_err" in self.altdata:
+            metadata["dec_unc"] = self.altdata["dec_err"]
+        if "time_stamp_alignment" in self.altdata:
+            metadata["time_stamp_alignment"] = self.altdata["time_stamp_alignment"]
+
+        for k, v in metadata.items():
+            if k is None:
+                raise ValueError(f"metadata key {k} is None")
 
         with pd.HDFStore(filename, mode="w") as store:
             store.put(

--- a/src/tess.py
+++ b/src/tess.py
@@ -779,6 +779,9 @@ class VirtualTESS(VirtualObservatory):
 
 
 if __name__ == "__main__":
+    import src.database
+
+    src.database.DATA_ROOT = "data"
     tess = VirtualTESS(project="testing VirtualTESS", verbose=0)
     white_dwarfs = Catalog(default="wd")
     white_dwarfs.load()

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1637,6 +1637,43 @@ def test_column_names_simplify_and_offset():
     assert get_time_offset("BJD - 2457000, days") == -2457000
 
 
+def test_export_skyportal_photometry(test_project, new_source, raw_phot):
+    assert isinstance(test_project.demo, VirtualDemoObs)
+    new_source.raw_photometry = [raw_phot]
+    lightcurves = test_project.demo.reduce(source=new_source, data_type="photometry")
+
+    lc = lightcurves[0]
+
+    filename = "test_skyportal_photometry.h5"
+    try:  # make sure to remove file at the end
+        lc.export_to_skyportal(filename)
+
+        with pd.HDFStore(filename) as store:
+            keys = store.keys()
+            assert len(keys) == 1
+            key = keys[0]
+            df = store[key]
+            for name in ["mjd", "flux", "fluxerr"]:
+                assert name in df.columns
+
+            metadata = store.get_storer(key).attrs["metadata"]
+
+            for name in [
+                "series_name",
+                "series_obj_id",
+                "exp_time",
+                "ra",
+                "dec",
+                "filter",
+                "time_stamp_alignment",
+            ]:
+                assert name in metadata
+
+    finally:
+        if os.path.isfile(filename):
+            os.remove(filename)
+
+
 def test_on_close_utility():
     a = []
     b = []


### PR DESCRIPTION
Added required fields to altdata to be able to export to skyportal. 
Added a Lightcurve function to save to disk an HDF5 file with the dataframe and metadata, in a format that fits the photometric series model in skyportal. 