### PR TITLE
Add a safe_mkdir that only makes folders inside limited places

### DIFF
--- a/src/analysis.py
+++ b/src/analysis.py
@@ -275,7 +275,7 @@ class Analysis:
                         non_empty += 1
             if non_empty == 0:
                 source.properties = Properties(
-                    has_data=False, project=self.pars.project
+                    has_data=False, project=self.pars.project, test_hash=self._test_hash
                 )
                 continue  # skip sources without data
 
@@ -537,7 +537,9 @@ class Analysis:
         """
         # TODO: calculate best S/N and so on...
 
-        source.properties = Properties(has_data=True, project=self.pars.project)
+        source.properties = Properties(
+            has_data=True, project=self.pars.project, test_hash=self._test_hash
+        )
 
     def _inject_to_lightcurves(self, lightcurves, source, index=0):
         """

--- a/src/analysis.py
+++ b/src/analysis.py
@@ -208,12 +208,17 @@ class Analysis:
         self.detections = []  # a list of Detection objects
         # TODO: should we limit the length of this list in memory?
 
+        self._test_hash = None
+
     def __setattr__(self, key, value):
         if key == "output_folder":
             if hasattr(self, "quality_values"):
                 self.quality_values.output_folder = value
                 self.all_scores.output_folder = value
                 self.good_scores.output_folder = value
+        if key == "_test_hash":
+            if hasattr(self, "finder"):
+                self.finder._test_hash = value
 
         super().__setattr__(key, value)
 

--- a/src/catalog.py
+++ b/src/catalog.py
@@ -354,8 +354,7 @@ class Catalog:
             if not os.path.isfile(self.get_fullpath()):
                 raise FileNotFoundError(f"File {self.get_fullpath()} not found.")
 
-        if self.pars.verbose:
-            print(f"Loading catalog from {self.get_fullpath()}")
+        self.pars.vprint(f"Loading catalog from {self.get_fullpath()}")
 
         # do the actual loading:
         type = self._guess_file_type()

--- a/src/catalog.py
+++ b/src/catalog.py
@@ -21,7 +21,7 @@ from astropy.io import fits
 
 from src.parameters import Parameters
 from src.source import Source
-from src.database import SmartSession
+from src.database import SmartSession, safe_mkdir
 from src.utils import help_with_class, help_with_object, ra2sex, dec2sex
 
 
@@ -393,8 +393,7 @@ class Catalog:
         downloaded_filename = SANITIZE_RE.sub("", downloaded_filename)
 
         with requests.get(URL, stream=True) as r:
-            if not os.path.isdir(path):
-                os.makedirs(path)
+            safe_mkdir(path)
             with open(downloaded_filename, "wb") as f:
                 print(f"Downloading {URL} \n to {downloaded_filename}")
                 shutil.copyfileobj(r.raw, f)
@@ -854,8 +853,7 @@ class Catalog:
         filename += f".{fmt}"
 
         path = os.path.dirname(filename)
-        if not os.path.isdir(path):
-            os.makedirs(path)
+        safe_mkdir(path)
 
         if fmt == "csv":
             df.to_csv(filename, index=False, header=True)

--- a/src/database.py
+++ b/src/database.py
@@ -33,7 +33,7 @@ if DATA_ROOT is None:  # TODO: should also check if folder exists?
     DATA_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "../data"))
 
 # this is the root AstroRetriever folder
-CODE_ROOT = os.path.abspath(os.path.join(__file__, os.pardir))
+CODE_ROOT = os.path.abspath(os.path.join(__file__, os.pardir, os.pardir))
 
 DATA_TEMP = os.path.join(CODE_ROOT, "DATA_TEMP")
 

--- a/src/database.py
+++ b/src/database.py
@@ -26,14 +26,15 @@ from sqlalchemy_utils import database_exists, create_database
 from sqlalchemy.orm import sessionmaker, declarative_base, scoped_session
 
 
+# this is the root AstroRetriever folder
+CODE_ROOT = os.path.abspath(os.path.join(__file__, os.pardir, os.pardir))
+
 # this is where the data lives
 # (could be changed for, e.g., new external drive)
 DATA_ROOT = os.getenv("RETRIEVER_DATA")
 if DATA_ROOT is None:  # TODO: should also check if folder exists?
-    DATA_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "../data"))
-
-# this is the root AstroRetriever folder
-CODE_ROOT = os.path.abspath(os.path.join(__file__, os.pardir, os.pardir))
+    # DATA_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "../data"))
+    DATA_ROOT = os.path.join(CODE_ROOT, "results")
 
 DATA_TEMP = os.path.join(CODE_ROOT, "DATA_TEMP")
 
@@ -165,7 +166,12 @@ def SmartSession(input_session=None):
 
 def safe_mkdir(path):
 
-    allowed_dirs = [DATA_ROOT, os.path.join(CODE_ROOT, "results"), DATA_TEMP]
+    allowed_dirs = [
+        DATA_ROOT,
+        os.path.join(CODE_ROOT, "results"),
+        os.path.join(CODE_ROOT, "catalogs"),
+        DATA_TEMP,
+    ]
 
     ok = False
 
@@ -180,6 +186,7 @@ def safe_mkdir(path):
     if not ok:
         err_str = "Cannot make a new folder not inside the following folders: "
         err_str += "\n".join(allowed_dirs)
+        err_str += f"\n\nAttempted folder: {path}"
         raise ValueError(err_str)
 
     # if the path is ok, also make the subfolders

--- a/src/database.py
+++ b/src/database.py
@@ -33,7 +33,6 @@ CODE_ROOT = os.path.abspath(os.path.join(__file__, os.pardir, os.pardir))
 # (could be changed for, e.g., new external drive)
 DATA_ROOT = os.getenv("RETRIEVER_DATA")
 if DATA_ROOT is None:  # TODO: should also check if folder exists?
-    # DATA_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "../data"))
     DATA_ROOT = os.path.join(CODE_ROOT, "results")
 
 DATA_TEMP = os.path.join(CODE_ROOT, "DATA_TEMP")

--- a/src/database.py
+++ b/src/database.py
@@ -221,18 +221,19 @@ def clear_tables():
         pass
 
 
-def clear_test_objects():
+def clear_test_objects(specific_hash=None):
     from src.source import Source
     from src.dataset import RawPhotometry, Lightcurve
     from src.detection import Detection
     from src.properties import Properties
 
-    with Session() as session:
-        session.execute(sa.delete(Properties).where(Source.test_hash.is_not(None)))
-        session.execute(sa.delete(Detection).where(Source.test_hash.is_not(None)))
-        session.execute(sa.delete(Lightcurve).where(Source.test_hash.is_not(None)))
-        session.execute(sa.delete(RawPhotometry).where(Source.test_hash.is_not(None)))
-        session.execute(sa.delete(Source).where(Source.test_hash.is_not(None)))
+    for tab in [Properties, Detection, Lightcurve, RawPhotometry, Source]:
+        with SmartSession() as session:
+            if specific_hash is None:
+                session.execute(sa.delete(tab).where(tab.test_hash.is_not(None)))
+            else:
+                session.execute(sa.delete(tab).where(tab.test_hash == specific_hash))
+            session.commit()
 
 
 class RetrieverBase:
@@ -265,7 +266,6 @@ class RetrieverBase:
     test_hash = sa.Column(
         sa.String,
         nullable=True,
-        default=False,
         doc="Apply this to any test objects, "
         "either in the testing suite or when "
         "just debugging code interactively. "

--- a/src/dataset.py
+++ b/src/dataset.py
@@ -22,16 +22,13 @@ from sqlalchemy.schema import UniqueConstraint
 
 from sqlalchemy.dialects.postgresql import JSONB
 
+import src.database
 from src.database import engine, Base, SmartSession, safe_mkdir
 from src.source import Source
 from src.utils import random_string, legalize
 
 lock = threading.Lock()
 
-# root folder is either defined via an environment variable
-# or is the in the main repository, under subfolder "data"
-
-import src.database
 
 PHOT_ZP = 23.9
 LOG_BASE = np.log(10) / 2.5

--- a/src/dataset.py
+++ b/src/dataset.py
@@ -22,7 +22,7 @@ from sqlalchemy.schema import UniqueConstraint
 
 from sqlalchemy.dialects.postgresql import JSONB
 
-from src.database import engine, Base, SmartSession
+from src.database import engine, Base, SmartSession, safe_mkdir
 from src.source import Source
 
 
@@ -843,8 +843,7 @@ class DatasetMixin:
 
         # make a path if missing
         path = os.path.dirname(self.get_fullname())
-        if not os.path.isdir(path):
-            os.makedirs(path)
+        safe_mkdir(path)
 
         # specific format save functions
         if self.format == "hdf5":

--- a/src/dataset.py
+++ b/src/dataset.py
@@ -24,7 +24,7 @@ from sqlalchemy.dialects.postgresql import JSONB
 
 from src.database import engine, Base, SmartSession, safe_mkdir
 from src.source import Source
-from src.utils import random_string
+from src.utils import random_string, legalize
 
 lock = threading.Lock()
 
@@ -364,6 +364,8 @@ class DatasetMixin:
             if not isinstance(value, Source):
                 raise ValueError(f"Source must be a Source object, not {type(value)}")
             self.source_name = value.name
+        if key == "project" and value is not None:
+            value = legalize(value)
 
         super().__setattr__(key, value)
 
@@ -450,7 +452,7 @@ class DatasetMixin:
         if self.folder is not None:
             f = self.folder
         elif hasattr(self, "project") and self.project is not None:
-            f = self.project.upper()
+            f = self.project
         elif self.observatory is not None:
             f = self.observatory.upper()
         else:

--- a/src/dataset.py
+++ b/src/dataset.py
@@ -24,7 +24,7 @@ from sqlalchemy.dialects.postgresql import JSONB
 
 from src.database import engine, Base, SmartSession, safe_mkdir
 from src.source import Source
-
+from src.utils import random_string
 
 lock = threading.Lock()
 
@@ -586,11 +586,6 @@ class DatasetMixin:
     def load_netcdf(self):
         pass
 
-    @staticmethod
-    def random_string(length=16):
-        letters = list(string.ascii_lowercase)
-        return "".join(np.random.choice(letters, length))
-
     def invent_filename(
         self, source_name=None, ra_deg=None, ra_minute=None, ra_second=None
     ):
@@ -673,7 +668,7 @@ class DatasetMixin:
             if source_name is None:
                 source_name = self.source_name
             if source_name is None:
-                source_name = self.random_string()
+                source_name = random_string()
             # need to make up a file name in a consistent way
             if ra_second is not None and (ra_deg is None or ra_minute is None):
                 raise ValueError(
@@ -695,7 +690,7 @@ class DatasetMixin:
                         binning += f"{ra:02d}s"
 
             else:
-                binning = self.random_string(15)
+                binning = random_string(15)
 
             # add prefix using the type of data and observatory
             obs = self.observatory.upper() if self.observatory else "UNKNOWN_OBS"
@@ -750,7 +745,7 @@ class DatasetMixin:
             else:
                 raise TypeError("source name must be a string")
         else:
-            self.filekey = self.random_string(8)
+            self.filekey = random_string(8)
 
         # add the type of data
         self.filekey = f"{self.type}_{self.filekey}"
@@ -1249,6 +1244,7 @@ class DatasetMixin:
         "public",
         "observatory",
         "cfg_hash",
+        "test_hash",
         "folder",
         "colmap",
         "time_info",

--- a/src/dataset.py
+++ b/src/dataset.py
@@ -366,7 +366,8 @@ class DatasetMixin:
             self.source_name = value.name
         if key == "project" and value is not None:
             value = legalize(value)
-
+        if key == "observatory" and value is not None:
+            value = legalize(value)
         super().__setattr__(key, value)
 
     @orm.reconstructor
@@ -1753,7 +1754,7 @@ class Lightcurve(DatasetMixin, Base):
                         new_filt = kwargs["filtmap"]
                         if self.observatory:
                             new_filt = new_filt.replace(
-                                "<observatory>", self.observatory
+                                "<observatory>", self.observatory.lower()
                             )
                         return new_filt.replace("<filter>", filt)
 

--- a/src/detection.py
+++ b/src/detection.py
@@ -7,6 +7,8 @@ from sqlalchemy.ext.declarative import declared_attr
 from src.database import Base, engine
 from src.source import Source
 from src.dataset import RawPhotometry, Lightcurve
+from src.utils import legalize
+
 
 utcnow = func.timezone("UTC", func.current_timestamp())
 
@@ -233,6 +235,9 @@ class Detection(Base):
         """
         if key == "source":
             self.source_name = value.name
+        if key == "project" and value is None:
+            value = legalize(value)
+
         super().__setattr__(key, value)
 
 

--- a/src/finder.py
+++ b/src/finder.py
@@ -90,6 +90,7 @@ class Finder:
     def __init__(self, **kwargs):
         self.pars = self._make_pars_object(kwargs)
         self.checker = None
+        self._test_hash = None
 
     @staticmethod
     def _make_pars_object(kwargs):

--- a/src/histogram.py
+++ b/src/histogram.py
@@ -5,6 +5,7 @@ import numpy as np
 import pandas as pd
 import xarray as xr
 
+from src.database import safe_mkdir
 from src.parameters import Parameters
 from src.source import Source
 from src.utils import help_with_class, help_with_object, unit_convert_bytes, is_scalar
@@ -257,13 +258,6 @@ class Histogram:
 
         self.data.attrs["source_names"] = []
         self.source_names = set()
-
-        if self.output_folder is None:
-            self.output_folder = os.getcwd()
-
-        # create the output folder
-        if not os.path.exists(self.output_folder):
-            os.makedirs(self.output_folder)
 
     @staticmethod
     def _make_pars_object(kwargs):
@@ -949,6 +943,9 @@ class Histogram:
         filename, after the extension
         (e.g., "histograms_all_score.nc.temp")
         """
+        # make sure folder is there
+        if not os.path.isdir(self.output_folder):
+            safe_mkdir(self.output_folder)
 
         fullname = self.get_fullname(suffix=suffix)
         # netCDF files can't store dicts, must convert to string

--- a/src/observatory.py
+++ b/src/observatory.py
@@ -22,7 +22,7 @@ from src.parameters import (
 from src.source import Source, get_source_identifiers
 from src.dataset import DatasetMixin, RawPhotometry, Lightcurve, commit_and_save
 from src.catalog import Catalog
-from src.utils import help_with_class, help_with_object, CircularBufferList
+from src.utils import help_with_class, help_with_object, CircularBufferList, legalize
 
 lock = threading.Lock()
 
@@ -272,6 +272,13 @@ class VirtualObservatory:
             # are given by the config/user inputs
             # prefer to use that instead of the file content
             self._credentials.update(self.pars.credentials)
+
+    def __setattr__(self, key, value):
+
+        if key == "name" and value is not None:
+            value = legalize(value)
+
+        super().__setattr__(key, value)
 
     @property
     def project(self):

--- a/src/observatory.py
+++ b/src/observatory.py
@@ -1404,7 +1404,7 @@ class VirtualDemoObs(VirtualObservatory):
             sim_args_default.update(sim_args)
             sim_args = sim_args_default
 
-        self.pars.print(
+        self.pars.vprint(
             f'Fetching data from demo observatory for source {cat_row["cat_index"]}'
         )
         total_wait_time_seconds = wait_time + np.random.poisson(wait_time_poisson)

--- a/src/observatory.py
+++ b/src/observatory.py
@@ -255,6 +255,7 @@ class VirtualObservatory:
         self.latest_source = None
         self.latest_reductions = None
         self.num_loaded = None
+        self._test_hash = None
         self.reset()
 
         if not isinstance(self.project, str):
@@ -644,7 +645,12 @@ class VirtualObservatory:
             # if not, create one now
             if source is None:
                 self.pars.vprint(f'Creating new source: {cat_row["name"]}', 9)
-                source = Source(**cat_row, project=self.project, cfg_hash=self.cfg_hash)
+                source = Source(
+                    **cat_row,
+                    project=self.project,
+                    cfg_hash=self.cfg_hash,
+                    test_hash=self._test_hash,
+                )
                 source.cat_row = cat_row  # save the raw catalog row as well
                 report_dict["source"] = "new"
 
@@ -743,6 +749,7 @@ class VirtualObservatory:
 
                     dataset_args["colmap"] = colmap
                     dataset_args["time_info"] = time_info
+                    dataset_args["test_hash"] = self._test_hash
 
                     # create a raw data for this class (e.g., RawPhotometry)
                     raw_data = DataClass(

--- a/src/parameters.py
+++ b/src/parameters.py
@@ -3,6 +3,7 @@ import copy
 import yaml
 
 from src.database import DATA_ROOT
+from src.utils import legalize
 
 # A cached dictionary of dictionaries
 # loaded form YAML files.
@@ -303,6 +304,9 @@ class Parameters:
 
         if new_attrs_check and key not in self.__dict__ and key not in propagated_keys:
             raise AttributeError(f'Attribute "{key}" does not exist.')
+
+        if key == "project" and value is not None:
+            value = legalize(value)
 
         if key == "data_types":
             value = normalize_data_types(value)

--- a/src/parameters.py
+++ b/src/parameters.py
@@ -765,8 +765,9 @@ class Parameters:
         filename = inputs.get("cfg_file", None)
         explicit = filename is not None
 
-        if filename is None:
-            filename = inputs.get("project", None)
+        if filename is None and "project" in inputs:
+            filename = inputs["project"]
+            filename = legalize(filename, to_lower=True)
 
         cfg_key = inputs.get("cfg_key", None)
 

--- a/src/parameters.py
+++ b/src/parameters.py
@@ -143,7 +143,8 @@ class Parameters:
     - get_data_path() returns the path to the data folder.
     - get_class_instance() create a contained object using the keywords in this object.
     - add_defaults_to_dict() adds some attributes that should be shared to all pars.
-    - print() shows the parameters and descriptions.
+    - show_pars() shows the parameters and descriptions.
+    - vprint() prints the text given if the verbose level exceeds a threshold.
 
     Adding new parameters
     ---------------------
@@ -633,7 +634,7 @@ class Parameters:
             if k in self and k not in inputs:
                 inputs[k] = self[k]
 
-    def print(self, owner_pars=None):
+    def show_pars(self, owner_pars=None):
         """
         Print the parameters.
 
@@ -665,6 +666,24 @@ class Parameters:
             max_length = max(len(n) for n in names)
             for n, d in zip(names, desc):
                 print(f" {n:>{max_length}}{d}")
+
+    def vprint(self, text, threshold=1):
+        """
+        Print the text to standard output, but only
+        if the verbose level is above a given threshold.
+
+        Parameters
+        ----------
+        text: str
+            The text to print.
+        threshold: bool or int
+            The minimal level of the verbose parameter needed
+            to print out the text. If self.verbose is lower
+            than that, nothing will be printed.
+
+        """
+        if self.verbose > threshold:
+            print(text)
 
     def compare(self, other, hidden=False, ignore=None, verbose=False):
         """

--- a/src/project.py
+++ b/src/project.py
@@ -15,7 +15,7 @@ import numpy as np
 import sqlalchemy as sa
 
 import src.database
-from src.database import Base, SmartSession
+from src.database import Base, SmartSession, safe_mkdir
 from src.parameters import Parameters, get_class_from_data_type
 from src.catalog import Catalog
 from src.observatory import ParsObservatory
@@ -944,11 +944,11 @@ class Project:
         if self.pars.version_control:
             self.output_folder += f"_{self.cfg_hash}"
 
+        print(f"DATA_ROOT= {src.database.DATA_ROOT}")
         self.output_folder = os.path.join(src.database.DATA_ROOT, self.output_folder)
 
         # create the output folder
-        if not os.path.exists(self.output_folder):
-            os.makedirs(self.output_folder)
+        safe_mkdir(self.output_folder)
 
         self.analysis.output_folder = self.output_folder
 

--- a/src/project.py
+++ b/src/project.py
@@ -296,6 +296,7 @@ class Project:
         # filled by _setup_output_folder at runtime:
         self.output_folder = None
         self.cfg_hash = None  # hash of the config file (for version control)
+        self._test_hash = None
 
         # version control:
         if self.pars.version_control:
@@ -335,6 +336,16 @@ class Project:
 
         self.sources = None  # list to be filled by analysis
         self.num_sources_scanned = None
+
+    def __setattr__(self, key, value):
+        if key == "_test_hash":
+            if hasattr(self, "analysis"):
+                self.analysis._test_hash = value
+            if hasattr(self, "observatories"):
+                for obs in self.observatories:
+                    obs._test_hash = value
+
+        super().__setattr__(key, value)
 
     @staticmethod
     def _make_pars_object(kwargs):
@@ -434,6 +445,7 @@ class Project:
 
         # the catalog is just referenced from the project
         new_obs.catalog = self.catalog
+        new_obs._test_hash = self._test_hash
 
         if not hasattr(self, name.lower()):
             setattr(self, name.lower(), new_obs)

--- a/src/project.py
+++ b/src/project.py
@@ -944,7 +944,6 @@ class Project:
         if self.pars.version_control:
             self.output_folder += f"_{self.cfg_hash}"
 
-        print(f"DATA_ROOT= {src.database.DATA_ROOT}")
         self.output_folder = os.path.join(src.database.DATA_ROOT, self.output_folder)
 
         # create the output folder

--- a/src/project.py
+++ b/src/project.py
@@ -24,7 +24,13 @@ from src.dataset import RawPhotometry, Lightcurve
 from src.analysis import Analysis
 from src.properties import Properties
 from src.detection import Detection
-from src.utils import help_with_class, help_with_object, NamedList, CircularBufferList
+from src.utils import (
+    help_with_class,
+    help_with_object,
+    NamedList,
+    CircularBufferList,
+    legalize,
+)
 
 
 class ParsProject(Parameters):
@@ -338,6 +344,8 @@ class Project:
         self.num_sources_scanned = None
 
     def __setattr__(self, key, value):
+        if key == "name" and value is not None:
+            value = legalize(value)
         if key == "_test_hash":
             if hasattr(self, "analysis"):
                 self.analysis._test_hash = value
@@ -447,8 +455,9 @@ class Project:
         new_obs.catalog = self.catalog
         new_obs._test_hash = self._test_hash
 
-        if not hasattr(self, name.lower()):
-            setattr(self, name.lower(), new_obs)
+        shorthand = legalize(name, to_lower=True)
+        if not hasattr(self, shorthand):
+            setattr(self, shorthand, new_obs)
 
         return new_obs
 

--- a/src/properties.py
+++ b/src/properties.py
@@ -7,6 +7,8 @@ from src.database import Base, engine
 from src.source import Source
 from sqlalchemy import orm, func
 
+from src.utils import legalize
+
 utcnow = func.timezone("UTC", func.current_timestamp())
 
 
@@ -22,6 +24,13 @@ class Properties(Base):
             name="_properties_source_name_in_project_uc",
         ),
     )
+
+    def __setattr__(self, key, value):
+        if key == "project" and value is not None:
+            value = legalize(value)
+
+        super().__setattr__(key, value)
+
     # source_id = sa.Column(
     #     sa.ForeignKey("sources.id", ondelete="CASCADE"),
     #     nullable=False,

--- a/src/source.py
+++ b/src/source.py
@@ -20,7 +20,7 @@ from src.parameters import (
     convert_data_type,
     get_class_from_data_type,
 )
-from src.utils import ra2sex, dec2sex, add_alias, UniqueList
+from src.utils import ra2sex, dec2sex, add_alias, UniqueList, legalize
 
 
 DEFAULT_PROJECT = "test_project"
@@ -293,6 +293,10 @@ class Source(Base, conesearch_alchemy.Point):
             value.source_name = self.name
             value.project = self.project
             value.cfg_hash = self.cfg_hash
+
+        if key == "project" and value is not None:
+            value = legalize(value)
+
         super().__setattr__(key, value)
 
     rp = add_alias("raw_photometry")

--- a/src/tess.py
+++ b/src/tess.py
@@ -1,6 +1,7 @@
 import os
 import glob
 import requests
+from collections import defaultdict
 from datetime import datetime
 import numpy as np
 import pandas as pd
@@ -156,8 +157,12 @@ class VirtualTESS(VirtualObservatory):
         altdata_base = init_kwargs.pop("altdata", dataset.altdata)
 
         # split the dataframe into sectors
+        if len(dataset.data) == 0:
+            return []
         dfs = dataset.data.groupby("SECTOR")
         sectors = [df[0] for df in dfs]
+        # print(sectors)
+        # print([a['SECTOR'] for a in altdata_base['file_headers']])
         new_datasets = []
         for df_tuple in dfs:
             sector = df_tuple[0]
@@ -165,8 +170,8 @@ class VirtualTESS(VirtualObservatory):
             new_altdata = altdata_base.copy()
             new_altdata["sectors"] = sector
             new_altdata["filter"] = "TESS"
-            idx = None
 
+            idx = None
             for i in range(len(sectors)):
                 if int(altdata_base["file_headers"][i]["SECTOR"]) == int(sector):
                     idx = i
@@ -657,11 +662,13 @@ class VirtualTESS(VirtualObservatory):
 
         base_url = "https://mast.stsci.edu/api/v0.1/Download/file?uri="
 
+        sectors = []
         df_list = []
-        altdata = {}
-        altdata["TICID"] = int(ticid)
+        file_header_list = []
+        lc_header_list = []
+        aperture_list = []
+        ap_header_list = []
 
-        sectors = set()
         for i in lc_indices:
             uri = data_query["dataURL"][i]
             (
@@ -672,32 +679,52 @@ class VirtualTESS(VirtualObservatory):
                 aperture_header,
             ) = self._try_open_fits(base_url + uri)
 
-            sectors.add(file_header["SECTOR"])
+            sectors.append(file_header["SECTOR"])
             lightcurve_data["SECTOR"] = file_header["SECTOR"]
             # get the exposure time from the header
             lightcurve_data["EXPTIME"] = lightcurve_header["EXPOSURE"]
             df_list.append(lightcurve_data)
 
-            if "file_headers" not in altdata:
-                altdata["file_headers"] = []
-            altdata["file_headers"].append(file_header)
+            file_header_list.append(file_header)
+            lc_header_list.append(lightcurve_header)
 
-            if "lightcurve_headers" not in altdata:
-                altdata["lightcurve_headers"] = []
-            altdata["lightcurve_headers"].append(lightcurve_header)
-
-            if "aperture_arrays" not in altdata:
-                altdata["aperture_arrays"] = []
             # convert the aperture matrix into a nested list
-            altdata["aperture_arrays"].append(aperture_array.tolist())
-            if "aperture_headers" not in altdata:
-                altdata["aperture_headers"] = []
-            altdata["aperture_headers"].append(aperture_header)
+            aperture_list.append(aperture_array.tolist())
+            ap_header_list.append(aperture_header)
 
+        # go over the dataframes and find the ones with the most exposures per sector:
+        new_file_header_list = []
+        new_lc_header_list = []
+        new_aperture_list = []
+        new_ap_header_list = []
+        new_df_list = []
+        unique_sectors = list(set(sectors))
+        unique_sectors.sort()
+        for s in unique_sectors:
+            best_len = 0
+            best_idx = None
+            for i, (df, h) in enumerate(zip(df_list, file_header_list)):
+                if h["SECTOR"] == s and len(df) > best_len:
+                    best_len = len(df)
+                    best_idx = i
+
+            new_df_list.append(df_list[best_idx])
+            new_file_header_list.append(file_header_list[best_idx])
+            new_lc_header_list.append(lc_header_list[best_idx])
+            new_aperture_list.append(aperture_list[best_idx])
+            new_ap_header_list.append(ap_header_list[best_idx])
+
+        altdata = dict(TICID=int(ticid), filter="TESS")
+
+        altdata["SECTORS"] = unique_sectors
+        altdata["file_headers"] = new_file_header_list
+        altdata["lightcurve_headers"] = new_lc_header_list
+        altdata["aperture_arrays"] = new_aperture_list
+        altdata["aperture_headers"] = new_ap_header_list
         self._get_exposure_time(altdata)
-        altdata["filter"] = "TESS"
 
-        data = pd.concat(df_list, ignore_index=True)
+        data = pd.concat(new_df_list, ignore_index=True)
+
         altdata["sectors"] = list(sectors)
 
         return data, altdata

--- a/src/tess.py
+++ b/src/tess.py
@@ -564,7 +564,7 @@ class VirtualTESS(VirtualObservatory):
 
         if mag > 16:
             # TESS can't see stars fainter than 16 mag
-            self._print(f"Magnitude of {mag} is too faint for TESS.", self.pars.verbose)
+            self.pars.vprint(f"Magnitude of {mag} is too faint for TESS.")
             return pd.DataFrame(), {}
 
         cat_params = {
@@ -576,9 +576,7 @@ class VirtualTESS(VirtualObservatory):
             Catalogs.query_region, cat_params, self.pars.verbose
         )
         if len(catalog_data) == 0:
-            self._print(
-                "No TESS object found for given catalog row.", self.pars.verbose
-            )
+            self.pars.vprint("No TESS object found for given catalog row.")
             return pd.DataFrame(), {}
 
         candidate_idx = None
@@ -598,9 +596,8 @@ class VirtualTESS(VirtualObservatory):
                 break
 
         if candidate_idx is None:
-            self._print(
+            self.pars.vprint(
                 "No objects found within mag difference threshold for TIC query.",
-                self.pars.verbose,
             )
             return pd.DataFrame(), {}
 
@@ -639,12 +636,10 @@ class VirtualTESS(VirtualObservatory):
         )
 
         if len(data_query) == 0:
-            self._print(f"No data found for object {tess_name}.", self.pars.verbose)
+            self.pars.vprint(f"No data found for object {tess_name}.")
             return pd.DataFrame(), {}
         if ticid not in data_query["target_name"]:
-            self._print(
-                f"No timeseries data found for object {tess_name}.", self.pars.verbose
-            )
+            self.pars.vprint(f"No timeseries data found for object {tess_name}.")
             return pd.DataFrame(), {}
 
         lc_indices = []
@@ -655,15 +650,10 @@ class VirtualTESS(VirtualObservatory):
                 lc_indices.append(i)
 
         if not lc_indices:
-            self._print(
-                f"No lightcurve data found for object {tess_name}.", self.pars.verbose
-            )
+            self.pars.vprint(f"No lightcurve data found for object {tess_name}.")
             return pd.DataFrame(), {}
 
-        self._print(
-            f"Found {len(lc_indices)} light curve(s) for this source.",
-            self.pars.verbose,
-        )
+        self.pars.vprint(f"Found {len(lc_indices)} light curve(s) for this source.")
 
         base_url = "https://mast.stsci.edu/api/v0.1/Download/file?uri="
 
@@ -720,13 +710,13 @@ class VirtualTESS(VirtualObservatory):
         # maybe try using multiprocessing to terminate after 10 secs?
         for tries in range(10):
             try:
-                self._print(
-                    f"Making query request, " f"attempt {tries + 1}/10 ...", verbose
+                self.pars.vprint(
+                    f"Making query request, " f"attempt {tries + 1}/10 ..."
                 )
                 ret = query_fn(**params)
                 return ret
             except TimeoutError as e:
-                self._print(f"Request timed out.", verbose)
+                self.pars.vprint(f"Request timed out.")
 
         raise TimeoutError(f"Too many timeouts from query request.")
 
@@ -777,13 +767,6 @@ class VirtualTESS(VirtualObservatory):
                 continue
 
         raise TimeoutError(f"Too many timeouts from trying to open fits.")
-
-    def _print(self, msg, verbose):
-        """
-        Verbose print helper.
-        """
-        if verbose > 0:
-            print(msg)
 
 
 if __name__ == "__main__":

--- a/src/tess.py
+++ b/src/tess.py
@@ -1,19 +1,11 @@
-import os
-import glob
-import requests
-from collections import defaultdict
 from datetime import datetime
 import numpy as np
 import pandas as pd
 import sqlalchemy as sa
-import warnings
 import socket
-
-from timeit import default_timer as timer
 
 from astroquery.mast import Observations, Catalogs
 from astropy.coordinates import SkyCoord
-from astropy.time import Time
 import astropy.io.fits as fits
 
 # from src.source import angle_diff
@@ -161,8 +153,6 @@ class VirtualTESS(VirtualObservatory):
             return []
         dfs = dataset.data.groupby("SECTOR")
         sectors = [df[0] for df in dfs]
-        # print(sectors)
-        # print([a['SECTOR'] for a in altdata_base['file_headers']])
         new_datasets = []
         for df_tuple in dfs:
             sector = df_tuple[0]

--- a/src/utils.py
+++ b/src/utils.py
@@ -500,6 +500,10 @@ class UniqueList(list):
         return True
 
     def _compare(self, key1, key2):
+        """
+        Check if the two keys are the same.
+        If ignorecase is True, will convert to lower case.
+        """
         if self.ignorecase and isinstance(key1, str) and isinstance(key2, str):
             return key1.lower() == key2.lower()
         else:

--- a/src/utils.py
+++ b/src/utils.py
@@ -319,7 +319,7 @@ def add_alias(att):
     )
 
 
-def legalize(name):
+def legalize(name, to_lower=False):
     """
     Turn a given name for a project/observatory into a legal name.
     This trims whitespace, replaces inner spaces and dashes with underscores,
@@ -328,15 +328,26 @@ def legalize(name):
     to various search methods.
     All these names should be saved after being legalized, so they can be
     searched against a legalized version of the user input.
+
+    Parameters
+    ----------
+    name: str
+        The name to be legalized.
+    to_lower: bool
+        If True, will convert to lower case instead of upper case. Default is False.
+
     """
 
     name = name.strip()
     name = name.replace(" ", "_").replace("-", "_")
-    name = name.upper()
+    if to_lower:
+        name = name.lower()
+    else:
+        name = name.upper()
 
     if re.match(LEGAL_NAME_RE, name) is None:
         raise ValueError(
-            f'Cannot legalize name "{name}". Must be alphanumeric without leading number. '
+            f'Cannot legalize name "{name}". Must be alphanumeric without a leading number. '
         )
 
     return name

--- a/src/utils.py
+++ b/src/utils.py
@@ -3,6 +3,8 @@ Various utility functions and classes
 that were not relevant to any specific module.
 """
 import sys
+import string
+import re
 import numpy as np
 from datetime import datetime, timezone
 import dateutil.parser
@@ -11,6 +13,9 @@ from inspect import signature
 from astropy.coordinates import SkyCoord
 from astropy import units as u
 from astropy.time import Time
+
+
+LEGAL_NAME_RE = re.compile(r"^(?!\d)\w+$")
 
 
 class OnClose:
@@ -312,6 +317,38 @@ def add_alias(att):
         fset=lambda self, value: setattr(self, att, value),
         doc=f'Alias for "{att}"',
     )
+
+
+def legalize(name):
+    """
+    Turn a given name for a project/observatory into a legal name.
+    This trims whitespace, replaces inner spaces and dashes with underscores,
+    and pushes name up to upper case.
+    This allows some freedom when giving the name of the project/observatory
+    to various search methods.
+    All these names should be saved after being legalized, so they can be
+    searched against a legalized version of the user input.
+    """
+
+    name = name.strip()
+    name = name.replace(" ", "_").replace("-", "_")
+    name = name.upper()
+
+    if re.match(LEGAL_NAME_RE, name) is None:
+        raise ValueError(
+            f'Cannot legalize name "{name}". Must be alphanumeric without leading number. '
+        )
+
+    return name
+
+
+def random_string(length=16):
+    """
+    Generate a string of given length,
+    made of random letters.
+    """
+    letters = list(string.ascii_lowercase)
+    return "".join(np.random.choice(letters, length))
 
 
 class NamedList(list):

--- a/src/utils.py
+++ b/src/utils.py
@@ -100,7 +100,7 @@ def help_with_class(cls, pars_cls=None, sub_classes=None):
         print("Parameters:")
         # initialize a parameters object and print it
         pars = pars_cls(cfg_file=False)  # do not read config file
-        pars.print()  # show a list of parameters
+        pars.show_pars()  # show a list of parameters
         print()  # newline
 
     if sub_classes is not None:
@@ -122,7 +122,7 @@ def help_with_object(obj, owner_pars):
 
     if hasattr(obj, "pars"):
         print("Parameters:")
-        obj.pars.print(owner_pars)
+        obj.pars.show_pars(owner_pars)
         print()  # newline
         this_pars = obj.pars
 

--- a/src/ztf.py
+++ b/src/ztf.py
@@ -134,10 +134,9 @@ class VirtualZTF(VirtualObservatory):
 
         """
 
-        if verbose:
-            print(
-                f'Fetching data from ZTF observatory for source {cat_row["cat_index"]}'
-            )
+        self.pars.vprint(
+            f'Fetching data from ZTF observatory for source {cat_row["cat_index"]}'
+        )
 
         if (
             cat_row["dec"] < self.pars.minimal_declination

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,6 +38,9 @@ def data_dir():
 
 @pytest.fixture(scope="session", autouse=True)
 def example_data_dir():
+    # this is where you'd save example data, like lightcurves for surveys
+    # this folder is part of the repo and is not supposed to change.
+    # don't put temporary files in there, that's what data_dir is for!
     return os.path.abspath(os.path.join(os.path.dirname(__file__), "DATA"))
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,6 +37,11 @@ def data_dir():
 
 
 @pytest.fixture(scope="session", autouse=True)
+def example_data_dir():
+    return os.path.abspath(os.path.join(os.path.dirname(__file__), "DATA"))
+
+
+@pytest.fixture(scope="session", autouse=True)
 def test_hash():
     # mark all the test objects with this
     # and then delete them at the end

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -39,6 +39,7 @@ def test_load_save_parameters(data_dir):
 
     filename = "parameters_test.yaml"
     filename = os.path.abspath(os.path.join(data_dir, filename))
+    safe_mkdir(os.path.dirname(filename))
 
     # write an example parameters file
     with open(filename, "w") as file:
@@ -136,9 +137,11 @@ def test_project_user_inputs():
     assert proj.demo.pars.reduce_kwargs["reducer_key"] == "reducer_value2"
 
 
-def test_project_config_file(data_dir):
+def test_project_config_file():
     project_str1 = str(uuid.uuid4())
     project_str2 = str(uuid.uuid4())
+
+    configs_folder = os.path.join(src.database.CODE_ROOT, "configs")
 
     data = {
         "project": {  # project wide definitions
@@ -156,7 +159,7 @@ def test_project_config_file(data_dir):
             "ztf": {
                 "credentials": {
                     "filename": os.path.abspath(
-                        os.path.join(data_dir, "passwords_test.yaml")
+                        os.path.join(configs_folder, "passwords_test.yaml")
                     ),
                 },
                 "reduce_kwargs": {
@@ -171,13 +174,15 @@ def test_project_config_file(data_dir):
     }
 
     # make config and passwords file
-    configs_folder = os.path.abspath(os.path.join(data_dir, "../configs"))
-
     if not os.path.isdir(configs_folder):
         os.mkdir(configs_folder)
     filename = os.path.join(configs_folder, "default_test.yaml")
+
+    # make the config file
     with open(filename, "w") as file:
         yaml.dump(data, file, sort_keys=False)
+
+    # make the passwords file
     with open(data["observatories"]["ztf"]["credentials"]["filename"], "w") as file:
         password = str(uuid.uuid4())
         yaml.dump(

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -94,7 +94,7 @@ def test_load_save_parameters(data_dir):
 def test_default_project():
     proj = Project("default_test", catalog_kwargs={"default": "test"})
     assert proj.pars.obs_names == ["DEMO"]
-    assert "demo" in [obs.name for obs in proj.observatories]
+    assert "DEMO" in [obs.name for obs in proj.observatories]
     assert isinstance(proj.observatories[0], VirtualDemoObs)
 
 
@@ -117,7 +117,7 @@ def test_project_user_inputs():
     assert proj.catalog.pars.filename == "test.csv"
 
     # check the observatory was loaded correctly
-    assert "ztf" in [obs.name for obs in proj.observatories]
+    assert "ZTF" in [obs.name for obs in proj.observatories]
     idx = None
     for i, item in enumerate(proj.observatories):
         if isinstance(item, VirtualZTF):
@@ -747,7 +747,7 @@ def test_data_reduction(test_project, new_source, raw_phot_no_exptime):
         # reduce the data using the demo observatory
         assert len(test_project.observatories) == 1
         obs_key = list(test_project.observatories.keys())[0]
-        assert obs_key == "demo"
+        assert obs_key == "DEMO"
         obs = test_project.observatories[obs_key]
         assert isinstance(obs, VirtualDemoObs)
 
@@ -1881,6 +1881,20 @@ def test_unique_list():
     # check that array indexing works with two out of three attributes
     assert ul[["object one", "foo1"]] == [obj1]
     assert ul[["object two", "foo2"]] == [obj2]
+
+    # check that we can ignore case
+    obj4 = TempObject()
+    obj4.name = "Foo"
+
+    obj5 = TempObject()
+    obj5.name = "fOO"
+
+    ul = UniqueList(comparison_attributes=["name"], ignorecase=True)
+    ul.append(obj4)
+    ul.append(obj5)
+    assert len(ul) == 1
+    assert ul["foo"] == obj5
+    assert ul["FOO"] == obj5
 
 
 def test_circular_buffer_list():

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -11,7 +11,7 @@ from src.project import Project
 from src.observatory import VirtualDemoObs
 
 
-def test_project_histograms():
+def test_project_histograms(test_hash):
 
     filenames = []
 
@@ -24,6 +24,7 @@ def test_project_histograms():
             catalog_kwargs={"default": "test"},
             verbose=0,
         )
+        proj.test_hash = test_hash
         num_sources = len(proj.catalog.data)
 
         proj.demo.pars.check_data_exists = True
@@ -75,7 +76,7 @@ def test_project_histograms():
         assert not os.path.exists(os.path.join(proj.output_folder, "config.yaml"))
 
 
-def test_project_multiple_runs():
+def test_project_multiple_runs(test_hash):
     num_sources_with_data = 0
     filenames = []
 
@@ -88,6 +89,7 @@ def test_project_multiple_runs():
             catalog_kwargs={"default": "test"},
             verbose=0,
         )
+        proj.test_hash = test_hash
         num_sources = len(proj.catalog.data)
 
         assert isinstance(proj.demo, VirtualDemoObs)
@@ -170,7 +172,7 @@ def test_project_multiple_runs():
         assert not os.path.exists(os.path.join(proj.output_folder, "config.yaml"))
 
 
-def test_project_with_simulated_events():
+def test_project_with_simulated_events(test_hash):
     filenames = []
 
     try:  # cleanup at end
@@ -182,6 +184,7 @@ def test_project_with_simulated_events():
             catalog_kwargs={"default": "test"},
             verbose=0,
         )
+        proj.test_hash = test_hash
         num_sources = len(proj.catalog.data)
         obs = proj.observatories["demo"]
         assert isinstance(obs, VirtualDemoObs)

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -9,6 +9,7 @@ from pprint import pprint
 
 from src.project import Project
 from src.observatory import VirtualDemoObs
+from src.utils import legalize, random_string
 
 
 def test_project_histograms(test_hash):
@@ -174,10 +175,12 @@ def test_project_multiple_runs(test_hash):
 
 def test_project_with_simulated_events(test_hash):
     filenames = []
+    original_name = f" {random_string(8)}-{random_string(8)} 42"
+    legal_name = legalize(original_name)
 
     try:  # cleanup at end
         proj = Project(
-            name="default_test",
+            name=original_name,
             obs_names=["demo"],
             analysis_kwargs={"num_injections": 3},
             obs_kwargs={},
@@ -202,6 +205,11 @@ def test_project_with_simulated_events(test_hash):
             assert s.raw_photometry[0].get_fullname() is not None
             assert os.path.exists(s.raw_photometry[0].get_fullname())
             filenames.append(s.raw_photometry[0].get_fullname())
+
+            # check project name is legal
+            assert s.project == legal_name
+            assert s.reduced_photometry[0].project == legal_name
+            assert s.properties.project == legal_name
 
     # TODO: add simulator, check detections are found
     #  check the detections are all labelled as simulated

--- a/tests/test_tess.py
+++ b/tests/test_tess.py
@@ -41,9 +41,7 @@ def test_tess_download(tess_project, wd_cat):
     # download the lightcurve:
     tess_project.catalog = c
     tess.catalog = c
-    tess.fetch_all_sources(
-        reduce=False
-    )  # TODO: when finished adding reducer, remove this
+    tess.fetch_all_sources()
 
     def cleanup():  # to be called at the end
         with SmartSession() as session:
@@ -51,6 +49,9 @@ def test_tess_download(tess_project, wd_cat):
                 for p in s.raw_photometry:
                     p.delete_data_from_disk()
                     session.delete(p)
+                for lc in s.reduced_lightcurves:
+                    lc.delete_data_from_disk()
+                    session.delete(lc)
                 session.delete(s)
 
             session.commit()
@@ -97,7 +98,7 @@ def test_tess_download(tess_project, wd_cat):
         assert num_sources_with_data > 0
 
 
-def test_tess_reduction(tess_project, new_source):
+def test_tess_reduction(tess_project, new_source, test_hash):
     # make sure the project has tess observatory:
     assert len(tess_project.observatories) == 1
     assert "tess" in tess_project.observatories
@@ -110,6 +111,7 @@ def test_tess_reduction(tess_project, new_source):
     new_source.project = "test_TESS"
     colmap, time_info = tess.get_colmap_time_info()
     raw_data = RawPhotometry(observatory="tess", colmap=colmap, time_info=time_info)
+    raw_data.test_hash = test_hash
     raw_data.filename = "TESS_photometry.h5"
     raw_data.folder = "DATA"
     raw_data.load()

--- a/tests/test_tess.py
+++ b/tests/test_tess.py
@@ -266,13 +266,13 @@ def test_tess_download_by_ticid(tess_project):
         assert raw_phot is None
 
 
-def test_tess_to_skyportal_conversion(tess_project, new_source):
+def test_tess_to_skyportal_conversion(tess_project, new_source, example_data_dir):
     assert isinstance(tess_project.tess, VirtualTESS)
     colmap, time_info = tess_project.tess.get_colmap_time_info()
 
     raw_data = RawPhotometry(observatory="tess", colmap=colmap, time_info=time_info)
     raw_data.filename = "TESS_photometry.h5"
-    raw_data.folder = "DATA"
+    raw_data.folder = example_data_dir
     raw_data.load()
     new_source.raw_photometry.append(raw_data)
 

--- a/tests/test_tess.py
+++ b/tests/test_tess.py
@@ -98,7 +98,7 @@ def test_tess_download(tess_project, wd_cat):
         assert num_sources_with_data > 0
 
 
-def test_tess_reduction(tess_project, new_source, test_hash):
+def test_tess_reduction(tess_project, new_source, test_hash, example_data_dir):
     # make sure the project has tess observatory:
     assert len(tess_project.observatories) == 1
     assert "tess" in tess_project.observatories
@@ -113,7 +113,7 @@ def test_tess_reduction(tess_project, new_source, test_hash):
     raw_data = RawPhotometry(observatory="tess", colmap=colmap, time_info=time_info)
     raw_data.test_hash = test_hash
     raw_data.filename = "TESS_photometry.h5"
-    raw_data.folder = "DATA"
+    raw_data.folder = example_data_dir
     raw_data.load()
     new_source.raw_photometry.append(raw_data)
 
@@ -143,7 +143,7 @@ def test_tess_reduction(tess_project, new_source, test_hash):
     # TODO: more tests for this specific observatory reduction?
 
 
-def test_tess_analysis(tess_project, new_source):
+def test_tess_analysis(tess_project, new_source, example_data_dir):
     # make sure the project has tess observatory:
     assert len(tess_project.observatories) == 1
     assert "tess" in tess_project.observatories
@@ -157,7 +157,7 @@ def test_tess_analysis(tess_project, new_source):
     colmap, time_info = tess.get_colmap_time_info()
     raw_data = RawPhotometry(observatory="tess", colmap=colmap, time_info=time_info)
     raw_data.filename = "TESS_photometry.h5"
-    raw_data.folder = "DATA"
+    raw_data.folder = example_data_dir
     raw_data.load()
     new_source.raw_photometry.append(raw_data)
 
@@ -203,7 +203,7 @@ def test_tess_download_by_ticid(tess_project):
         source = tess.fetch_source(cat_row, reduce=False, save=True)
         source_name = source.name
         assert source.loaded_status == "new"
-        assert source.raw_photometry[0].observatory == "tess"
+        assert source.raw_photometry[0].observatory == "TESS"
         assert source.raw_photometry[0].loaded_status == "new"
 
         ticid = str(source.local_names["TESS"])
@@ -212,7 +212,7 @@ def test_tess_download_by_ticid(tess_project):
         source2 = tess.fetch_by_ticid(ticid, download=True, use_catalog=True)
         assert source2.loaded_status == "database"
         assert source2.name == source_name
-        assert source2.raw_photometry[0].observatory == "tess"
+        assert source2.raw_photometry[0].observatory == "TESS"
         assert source2.raw_photometry[0].loaded_status == "database"
 
         # delete the source and the re-fetch it using the TICID
@@ -224,7 +224,7 @@ def test_tess_download_by_ticid(tess_project):
         source3 = tess.fetch_by_ticid(ticid, download=True, use_catalog=True)
         assert source3.loaded_status == "new"
         assert source3.name == source_name
-        assert source3.raw_photometry[0].observatory == "tess"
+        assert source3.raw_photometry[0].observatory == "TESS"
         assert source3.raw_photometry[0].loaded_status == "database"
 
         # re-fetch using the TICID, without a catalog (name should be TICID)
@@ -232,7 +232,7 @@ def test_tess_download_by_ticid(tess_project):
         assert source4.loaded_status == "new"
         assert source4.name != source_name
         assert source4.name == ticid
-        assert source4.raw_photometry[0].observatory == "tess"
+        assert source4.raw_photometry[0].observatory == "TESS"
         assert source4.raw_photometry[0].loaded_status == "database"
 
     finally:

--- a/tests/test_ztf.py
+++ b/tests/test_ztf.py
@@ -76,7 +76,7 @@ def test_ztf_download(ztf_project, wd_cat):
             }
 
 
-def test_ztf_reduction(ztf_project, new_source):
+def test_ztf_reduction(ztf_project, new_source, example_data_dir):
     # make sure the project has ZTF observatory:
     assert len(ztf_project.observatories) == 1
     assert "ztf" in ztf_project.observatories
@@ -89,7 +89,7 @@ def test_ztf_reduction(ztf_project, new_source):
     new_source.project = "test_ZTF"
     raw_data = RawPhotometry(observatory="ztf")
     raw_data.filename = "ZTF_lightcurve.csv"
-    raw_data.folder = "DATA"
+    raw_data.folder = example_data_dir
     raw_data.load()
 
     # set the source mag to fit the data:


### PR DESCRIPTION
This takes care of checking if the folder exists (making it if it doesn't). 
But it also adds a check to make sure the folder is only created inside one of the allowed places:
1) the DATA_ROOT folder
2) the CODE_ROOT/results folder
3) the CODE_ROOT/DATA_TEMP folder

This should help make cleanup easier for e.g., tests that leave behind files and folders. 