### PR TITLE
Add preferred magnitude mapping to get alternate magnitude columns

### DIFF
--- a/src/tess.py
+++ b/src/tess.py
@@ -28,6 +28,8 @@ class ParsObsTESS(ParsObservatory):
 
         super().__init__("tess")
 
+        self.preferred_catalog_mag = "Gaia_RP"
+
         self.distance_thresh = self.add_par(
             "distance_thresh",
             10.0,
@@ -791,42 +793,43 @@ if __name__ == "__main__":
 
     src.database.DATA_ROOT = "data"
     tess = VirtualTESS(project="testing VirtualTESS", verbose=0)
-    white_dwarfs = Catalog(default="wd")
-    white_dwarfs.load()
 
-    print("finished loading catalog")
+    # white_dwarfs = Catalog(default="wd")
+    # white_dwarfs.load()
+    #
+    # print("finished loading catalog")
+    #
+    # count = 0
+    # for i in range(len(white_dwarfs.data)):
+    #     if i > 20:
+    #         break
+    #
+    #     cat_row = white_dwarfs.get_row(i, output="dict")
+    #     if cat_row["mag"] > 16:
+    #         continue
+    #
+    #     print(f"index={i}, cat_row: {cat_row}")
+    #     tess.fetch_source(cat_row, reduce=True, save=1)
 
-    count = 0
-    for i in range(len(white_dwarfs.data)):
-        if i > 20:
-            break
+    # result = tess.download_from_observatory(cat_row, verbose=1)
+    # if not result[1]:  # failed fetch returns empty dict
+    #     continue
+    #
+    #
+    #
+    # lc_data, altdata = result
+    # print(
+    #     f"TICID = {altdata['TICID']}, GAIA mag = {cat_row['mag']}, TESS mag = {altdata['TESSMAG']}"
+    # )
+    # count += 1
+    #
+    # ticid = altdata["TICID"]
+    # print("saving to disk...")
+    # lc_data.to_hdf(
+    #     "/Users/felix_3gpdyfd/astro_research/virtualobserver"
+    #     f"/notebook/tess_data_TEST/tess_lc_{ticid}.h5",
+    #     key="df",
+    # )
 
-        cat_row = white_dwarfs.get_row(i, output="dict")
-        if cat_row["mag"] > 16:
-            continue
-
-        print(f"index={i}, cat_row: {cat_row}")
-        tess.fetch_source(cat_row, reduce=True, save=1)
-
-        # result = tess.download_from_observatory(cat_row, verbose=1)
-        # if not result[1]:  # failed fetch returns empty dict
-        #     continue
-        #
-        #
-        #
-        # lc_data, altdata = result
-        # print(
-        #     f"TICID = {altdata['TICID']}, GAIA mag = {cat_row['mag']}, TESS mag = {altdata['TESSMAG']}"
-        # )
-        count += 1
-        #
-        # ticid = altdata["TICID"]
-        # print("saving to disk...")
-        # lc_data.to_hdf(
-        #     "/Users/felix_3gpdyfd/astro_research/virtualobserver"
-        #     f"/notebook/tess_data_TEST/tess_lc_{ticid}.h5",
-        #     key="df",
-        # )
-
-    print(f"\nFinal Count: {count}")
-    print(tess.latest_source.raw_photometry[0].loaded_status)
+    # print(f"\nFinal Count: {count}")
+    # print(tess.latest_source.raw_photometry[0].loaded_status)

--- a/tests/test_tess.py
+++ b/tests/test_tess.py
@@ -41,6 +41,12 @@ def test_tess_download(tess_project, wd_cat):
     # download the lightcurve:
     tess_project.catalog = c
     tess.catalog = c
+
+    # make sure TESS downloads based on the Gaia_RP and not Gaia_G
+    cat_row = tess._get_catalog_row(0)
+    assert isinstance(cat_row, dict)
+    assert cat_row["mag"] == tess.catalog.data["phot_rp_mean_mag"][0]
+
     tess.fetch_all_sources()
 
     def cleanup():  # to be called at the end


### PR DESCRIPTION
This adds two dictionaries to the Catalog class. They allow the user to `get_row` with a different magnitude, which lets different observatories get a more relevant magnitude band. 
As an example, the TESS bandpass is much closer to Gaia RP than to Gaia G. So this will allow the TESS download code to get that magnitude column when using `get_row`. 